### PR TITLE
Modified clone_repo method in ocdev/plugins/setup/setup.py

### DIFF
--- a/ocdev/plugins/setup/setup.py
+++ b/ocdev/plugins/setup/setup.py
@@ -166,12 +166,12 @@ class SetUp(Plugin):
 
         if directory:
             cmd.append(directory)
-        assert os.getcwdu() == '/var/www', "current working directory is {0}, needs to be '/var/www'".format(os.getcwdu())
-        assert not os.path.exists('/var/www/core'), '/var/www/core already exists, cannot create test instance'
+
+        assert not os.path.exists('{0}/core'.format(os.getcwdu())), 'cannot clone, {0}/core already exists'.format(os.getcwdu())
+        assert os.access(os.getcwdu(), os.W_OK), 'Insufficient privilege to write to this directory'
         try:
             result = check_call(cmd)
         except Exception as e:
             print(e)
-            print("likely failed due to lack of privileges")
             quit()
         return result

--- a/ocdev/plugins/setup/setup.py
+++ b/ocdev/plugins/setup/setup.py
@@ -167,8 +167,8 @@ class SetUp(Plugin):
         if directory:
             cmd.append(directory)
 
-        assert not os.path.exists('{0}/core'.format(os.getcwdu())), 'cannot clone, {0}/core already exists'.format(os.getcwdu())
-        assert os.access(os.getcwdu(), os.W_OK), 'Insufficient privilege to write to this directory'
+        assert not os.path.exists('{0}/core'.format(os.getcwd())), 'cannot clone, {0}/core already exists'.format(os.getcwd())
+        assert os.access(os.getcwd(), os.W_OK), 'Insufficient privilege to write to this directory'
         try:
             result = check_call(cmd)
         except Exception as e:

--- a/ocdev/plugins/setup/setup.py
+++ b/ocdev/plugins/setup/setup.py
@@ -166,6 +166,12 @@ class SetUp(Plugin):
 
         if directory:
             cmd.append(directory)
-
-
-        return check_call(cmd)
+        assert os.getcwdu() == '/var/www', "current working directory is {0}, needs to be '/var/www'".format(os.getcwdu())
+        assert not os.path.exists('/var/www/core'), '/var/www/core already exists, cannot create test instance'
+        try:
+            result = check_call(cmd)
+        except Exception as e:
+            print(e)
+            print("likely failed due to lack of privileges")
+            quit()
+        return result


### PR DESCRIPTION
Modified clone_repo method in ocdev/plugins/setup/setup.py to include better exception handelling and helpful statements on failure. Was trying to install it and it threw a generic error that the subprocess call failed but didn't include why.
