### PR TITLE
startapp.py fixed to be windows compatible

### DIFF
--- a/ocdev/plugins/startapp/startapp.py
+++ b/ocdev/plugins/startapp/startapp.py
@@ -157,7 +157,7 @@ class StartApp(Plugin):
             # then read the templates and create the parsed files
             for file in files:
                 abs_path = join(root, file)
-                jinja_path = relpath(abs_path, template_dir)
+                jinja_path = relpath(abs_path, template_dir).replace('\\', '/')
                 destination = join(app_dir, relpath(abs_path, app_template_dir))
 
                 rendered = env.get_template(jinja_path).render(params)


### PR DESCRIPTION
jinja2 loader.py seems to accepts only slashes as path separators (jinja2.exceptions.TemplateNotFound: 8.1\app\.travis.yml). So we replace all backslashes in template path with slashes.